### PR TITLE
Lesson 12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'skim'
 gem 'responders', '~> 2.0'
 gem 'omniauth'
 gem 'omniauth-facebook'
+gem 'omniauth-vkontakte'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'responders', '~> 2.0'
 gem 'omniauth'
 gem 'omniauth-facebook'
 gem 'omniauth-vkontakte'
+gem 'omniauth-twitter'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
@@ -52,6 +53,7 @@ gem 'omniauth-vkontakte'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'pry-byebug'
   # Use rspec и factory girl for tests
   gem 'rspec-rails'
   gem 'factory_girl_rails'

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'private_pub'
 gem 'thin'
 gem 'skim'
 gem 'responders', '~> 2.0'
+gem 'omniauth'
+gem 'omniauth-facebook'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development, :test do
   gem 'launchy'
   gem 'capybara-webkit'
   gem 'database_cleaner'
+  gem 'capybara-email'
 end
 
 group :test do
@@ -74,4 +75,5 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+  gem 'letter_opener'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-email (2.4.0)
+      capybara (~> 2.4)
+      mail
     capybara-webkit (1.7.1)
       capybara (>= 2.3.0, < 2.6.0)
       json
@@ -131,6 +134,8 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     libv8 (3.16.14.13)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -307,6 +312,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara
+  capybara-email
   capybara-webkit
   carrierwave
   cocoon
@@ -318,6 +324,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   less-rails
+  letter_opener
   omniauth
   omniauth-facebook
   omniauth-twitter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     faye (1.1.2)
       cookiejar (>= 0.3.0)
       em-http-request (>= 0.3.0)
@@ -107,6 +109,7 @@ GEM
       websocket-driver (>= 0.5.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashie (3.4.3)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     jbuilder (2.3.2)
@@ -117,6 +120,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jwt (1.5.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     less (2.6.0)
@@ -135,8 +139,24 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.2)
     multi_json (1.11.2)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
+    omniauth (1.3.1)
+      hashie (>= 1.2, < 4)
+      rack (>= 1.0, < 3)
+    omniauth-facebook (3.0.0)
+      omniauth-oauth2 (~> 1.2)
+    omniauth-oauth2 (1.4.0)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     orm_adapter (0.5.0)
     pg (0.18.3)
     private_pub (1.0.3)
@@ -277,6 +297,8 @@ DEPENDENCIES
   jquery-rails
   launchy
   less-rails
+  omniauth
+  omniauth-facebook
   pg
   private_pub
   rails (= 4.2.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       json (>= 1.7)
       mime-types (>= 1.16)
     cocoon (1.2.6)
+    coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -135,6 +136,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (5.8.2)
@@ -143,6 +145,7 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oauth (0.4.7)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -154,9 +157,15 @@ GEM
       rack (>= 1.0, < 3)
     omniauth-facebook (3.0.0)
       omniauth-oauth2 (~> 1.2)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-twitter (1.2.1)
+      json (~> 1.3)
+      omniauth-oauth (~> 1.1)
     omniauth-vkontakte (1.3.6)
       multi_json
       omniauth (~> 1.0)
@@ -165,6 +174,13 @@ GEM
     pg (0.18.3)
     private_pub (1.0.3)
       faye
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -241,6 +257,7 @@ GEM
       activesupport (>= 3.1, < 5.0)
       railties (>= 3.1, < 5.0)
       slim (~> 3.0)
+    slop (3.6.0)
     spring (1.4.0)
     sprockets (3.4.0)
       rack (> 1, < 3)
@@ -303,9 +320,11 @@ DEPENDENCIES
   less-rails
   omniauth
   omniauth-facebook
+  omniauth-twitter
   omniauth-vkontakte
   pg
   private_pub
+  pry-byebug
   rails (= 4.2.4)
   remotipart
   responders (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,10 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-vkontakte (1.3.6)
+      multi_json
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.1)
     orm_adapter (0.5.0)
     pg (0.18.3)
     private_pub (1.0.3)
@@ -299,6 +303,7 @@ DEPENDENCIES
   less-rails
   omniauth
   omniauth-facebook
+  omniauth-vkontakte
   pg
   private_pub
   rails (= 4.2.4)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,9 @@
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def facebook
+    @user = User.find_for_oauth(request.env['omniauth.auth'])
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: 'Facebook') if is_navigational_format?
+    end
+  end
+end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,9 +1,19 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def facebook
+    oauth_provider(:facebook)
+  end
+
+  def vkontakte
+    oauth_provider(:vkontakte)
+  end
+
+  private
+
+  def oauth_provider(provider)
     @user = User.find_for_oauth(request.env['omniauth.auth'])
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentication
-      set_flash_message(:notice, :success, kind: 'Facebook') if is_navigational_format?
+      set_flash_message(:notice, :success, kind: provider.to_s.humanize) if is_navigational_format?
     end
   end
 end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -20,11 +20,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, kind: provider.to_s.humanize) if is_navigational_format?
     else
       flash[:notice] = 'Please, specify your email for sign up'
-      render 'users/require_user_email', locals: { auth: auth }
+      session['devise.auth'] = { provider: request.env['omniauth.auth'].provider, uid: request.env['omniauth.auth'].uid }
+      render 'users/require_user_email'
     end
   end
 
   def auth
-    request.env['omniauth.auth'] || OmniAuth::AuthHash.new(params[:auth])
+    request.env['omniauth.auth'] || OmniAuth::AuthHash.new(params[:auth].merge!(session['devise.auth']))
   end
 end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -7,13 +7,24 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     oauth_provider(:vkontakte)
   end
 
+  def twitter
+    oauth_provider(:twitter)
+  end
+
   private
 
   def oauth_provider(provider)
-    @user = User.find_for_oauth(request.env['omniauth.auth'])
+    @user = User.find_for_oauth(auth)
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: provider.to_s.humanize) if is_navigational_format?
+    else
+      flash[:notice] = 'Please, specify your email for sign up'
+      render 'users/require_user_email', locals: { auth: auth }
     end
+  end
+
+  def auth
+    request.env['omniauth.auth'] || OmniAuth::AuthHash.new(params[:auth])
   end
 end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,0 +1,3 @@
+class Authorization < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ActiveRecord::Base
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:facebook, :vkontakte, :twitter]
 
   def author_of?(post)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:facebook]
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:facebook, :vkontakte]
 
   def author_of?(post)
     id == post.user_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,11 +2,12 @@ class User < ActiveRecord::Base
   has_many :questions, dependent: :destroy
   has_many :answers, dependent: :destroy
   has_many :votes
+  has_many :authorizations
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:facebook]
 
   def author_of?(post)
     id == post.user_id
@@ -14,5 +15,25 @@ class User < ActiveRecord::Base
 
   def voted?(post)
     votes.find_by(user: self, votable: post)
+  end
+
+  def self.find_for_oauth(auth)
+    authorization = Authorization.where(provider: auth.provider, uid: auth.uid.to_s).first
+    return authorization.user if authorization
+
+    email = auth.info[:email]
+    user = User.where(email: email).first
+    if user
+      user.create_authorization(auth)
+    else
+      password = Devise.friendly_token[0, 20]
+      user = User.create!(email: email, password: password, password_confirmation: password)
+      user.create_authorization(auth)
+    end
+    user
+  end
+
+  def create_authorization(auth)
+    self.authorizations.create(provider: auth.provider, uid: auth.uid.to_s)
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html
         - if user_signed_in? 
           = button_to 'Logout', destroy_user_session_path, class: 'btn btn-default navbar-btn navbar-right', method: :delete 
         - else 
-          = button_to 'Login', new_user_session_path, class: 'btn btn-default navbar-btn navbar-right' 
+          = button_to 'Login', new_user_session_path, class: 'btn btn-default navbar-btn navbar-right', method: :get 
     .row
       - if notice
         div class='alert alert-warning alert-dismissable'

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %> 
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/users/mailer/unlock_instructions.html.erb
+++ b/app/views/users/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,0 +1,39 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/require_user_email.html.slim
+++ b/app/views/users/require_user_email.html.slim
@@ -1,12 +1,9 @@
-= form_tag twitter_path, method: :post, class: 'form-horizontal' do
+= form_tag twitter_path, class: 'form-horizontal' do
   .form-group
     .col-sm-2.text-right
       = label_tag :email
     .col-sm-4
       = email_field 'auth[info]', :email
-  .form-group
-    = hidden_field_tag 'auth[provider]', auth.provider
-    = hidden_field_tag 'auth[uid]', auth.uid
   .form-group
     .col-sm-offset-2.col-sm-10
       = submit_tag 'Submit', class: 'btn btn-large btn-primary'

--- a/app/views/users/require_user_email.html.slim
+++ b/app/views/users/require_user_email.html.slim
@@ -1,0 +1,12 @@
+= form_tag twitter_path, method: :post, class: 'form-horizontal' do
+  .form-group
+    .col-sm-2.text-right
+      = label_tag :email
+    .col-sm-4
+      = email_field 'auth[info]', :email
+  .form-group
+    = hidden_field_tag 'auth[provider]', auth.provider
+    = hidden_field_tag 'auth[uid]', auth.uid
+  .form-group
+    .col-sm-offset-2.col-sm-10
+      = submit_tag 'Submit', class: 'btn btn-large btn-primary'

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  config.action_mailer.delivery_method = :letter_opener
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -235,7 +235,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :facebook, Rails.application.secrets.facebook_app_id, Rails.application.secrets.facebook_app_secret, info_fields: 'id,email'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -239,6 +239,7 @@ Devise.setup do |config|
   config.omniauth :vkontakte, Rails.application.secrets.vkontakte_app_id, Rails.application.secrets.vkontakte_app_secret, scope: [:email]
   config.omniauth :twitter, Rails.application.secrets.twitter_app_id, Rails.application.secrets.twitter_app_secret
 
+  config.reconfirmable = false
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -237,6 +237,7 @@ Devise.setup do |config|
   # up on your models and hooks.
   config.omniauth :facebook, Rails.application.secrets.facebook_app_id, Rails.application.secrets.facebook_app_secret, info_fields: 'id,email'
   config.omniauth :vkontakte, Rails.application.secrets.vkontakte_app_id, Rails.application.secrets.vkontakte_app_secret, scope: [:email]
+  config.omniauth :twitter, Rails.application.secrets.twitter_app_id, Rails.application.secrets.twitter_app_secret
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -236,6 +236,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   config.omniauth :facebook, Rails.application.secrets.facebook_app_id, Rails.application.secrets.facebook_app_secret, info_fields: 'id,email'
+  config.omniauth :vkontakte, Rails.application.secrets.vkontakte_app_id, Rails.application.secrets.vkontakte_app_secret, scope: [:email]
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: 'omniauth_callbacks' }
 
   concern :votable do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'omniauth_callbacks' }
 
+  devise_scope :user do
+    post '/twitter' => 'omniauth_callbacks#twitter'
+  end
+
   concern :votable do
     member do
       patch :vote_up

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,6 +12,8 @@
 
 development:
   secret_key_base: 6cfeffb0f2b2d70a1560f6df9b19fb0bfba1bdc5a5eb3d6164ed751c5f53ddb347e0738374f01f9e15ec7459e039b5e6ac9a4cefa09dbd81e2c3ce0c04ecf3c9
+  facebook_app_id: 1657185921211097
+  facebook_app_secret: e9070eb51b1dab448147af59172194af
 
 test:
   secret_key_base: aeaf39d682c2d84024d9a6760fdcb597279d074b784d9b1bd51e10293ed41fe497c97a12f2d176ba018e76911076de798874848b7118761ffeade06ed45d4e74

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,8 @@ development:
   secret_key_base: 6cfeffb0f2b2d70a1560f6df9b19fb0bfba1bdc5a5eb3d6164ed751c5f53ddb347e0738374f01f9e15ec7459e039b5e6ac9a4cefa09dbd81e2c3ce0c04ecf3c9
   facebook_app_id: 1657185921211097
   facebook_app_secret: e9070eb51b1dab448147af59172194af
+  vkontakte_app_id: 5198104
+  vkontakte_app_secret: ncJDBdoZAhprO6NOcXHi
 
 test:
   secret_key_base: aeaf39d682c2d84024d9a6760fdcb597279d074b784d9b1bd51e10293ed41fe497c97a12f2d176ba018e76911076de798874848b7118761ffeade06ed45d4e74

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,8 @@ development:
   facebook_app_secret: e9070eb51b1dab448147af59172194af
   vkontakte_app_id: 5198104
   vkontakte_app_secret: ncJDBdoZAhprO6NOcXHi
+  twitter_app_id: CDX0StIRcoPwTJNzmFhK9IFDC
+  twitter_app_secret: q1TTFX0PRfAlznvIHaltZnbstSvHGKJhTtHjJUKwkpYdpJMt4c
 
 test:
   secret_key_base: aeaf39d682c2d84024d9a6760fdcb597279d074b784d9b1bd51e10293ed41fe497c97a12f2d176ba018e76911076de798874848b7118761ffeade06ed45d4e74

--- a/db/migrate/20151221140247_create_authorizations.rb
+++ b/db/migrate/20151221140247_create_authorizations.rb
@@ -1,0 +1,11 @@
+class CreateAuthorizations < ActiveRecord::Migration
+  def change
+    create_table :authorizations do |t|
+      t.references :user, index: true, foreign_key: true
+      t.string :provider
+      t.string :uid, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151224140020_add_confirmable_to_device.rb
+++ b/db/migrate/20151224140020_add_confirmable_to_device.rb
@@ -1,0 +1,14 @@
+class AddConfirmableToDevice < ActiveRecord::Migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_index :users, :confirmation_token, unique: true
+
+    execute("UPDATE users SET confirmed_at = NOW()")
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151215162603) do
+ActiveRecord::Schema.define(version: 20151221140247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,17 @@ ActiveRecord::Schema.define(version: 20151215162603) do
   end
 
   add_index "attachments", ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type", using: :btree
+
+  create_table "authorizations", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "provider"
+    t.string   "uid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "authorizations", ["uid"], name: "index_authorizations_on_uid", using: :btree
+  add_index "authorizations", ["user_id"], name: "index_authorizations_on_user_id", using: :btree
 
   create_table "comments", force: :cascade do |t|
     t.text     "body"
@@ -94,6 +105,7 @@ ActiveRecord::Schema.define(version: 20151215162603) do
 
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "users"
+  add_foreign_key "authorizations", "users"
   add_foreign_key "comments", "users"
   add_foreign_key "questions", "users"
   add_foreign_key "votes", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151221140247) do
+ActiveRecord::Schema.define(version: 20151224140020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,8 +85,12 @@ ActiveRecord::Schema.define(version: 20151221140247) do
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
   end
 
+  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 

--- a/spec/acceptance/acceptance_helper.rb
+++ b/spec/acceptance/acceptance_helper.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-
+require 'capybara/email/rspec'
 RSpec.configure do |config|
   Capybara.javascript_driver = :webkit
 

--- a/spec/acceptance/authorization/sign_in_with_facebook_spec.rb
+++ b/spec/acceptance/authorization/sign_in_with_facebook_spec.rb
@@ -4,17 +4,15 @@ feature 'Sign in with facebook'do
   before { visit new_user_session_path }
 
   scenario 'user can sign in with his facebook account' do
-    expect(page).to have_link 'Sign in with Facebook'
-    facebook_auth_hash
-    click_on 'Sign in'
+    mock_auth_hash(:facebook)
+    click_on 'Sign in with Facebook'
 
     expect(page).to have_content 'Successfully authenticated from Facebook account'
   end
 
   scenario 'authentication error' do
     OmniAuth.config.mock_auth[:facebook] = :invalid_credentials
-    expect(page).to have_link 'Sign in with Facebook'
-    click_on 'Sign in'
+    click_on 'Sign in with Facebook'
 
     expect(page).to have_content 'Could not authenticate you from Facebook'
   end

--- a/spec/acceptance/authorization/sign_in_with_facebook_spec.rb
+++ b/spec/acceptance/authorization/sign_in_with_facebook_spec.rb
@@ -3,11 +3,27 @@ require_relative '../acceptance_helper'
 feature 'Sign in with facebook'do
   before { visit new_user_session_path }
 
-  scenario 'user can sign in with his facebook account' do
-    mock_auth_hash(:facebook)
-    click_on 'Sign in with Facebook'
+  describe 'User can sign in with his Facebook account' do
+    before do
+      mock_auth_hash(:facebook)
+      click_on 'Sign in with Facebook'
+    end
 
-    expect(page).to have_content 'Successfully authenticated from Facebook account'
+    scenario 'after conform email' do
+      open_email(OmniAuth.config.mock_auth[:facebook]['info']['email'])
+      current_email.click_link 'Confirm my account'
+      expect(page).to have_content 'Your email address has been successfully confirmed.'
+      click_on 'Sign in with Facebook'
+
+      expect(page).to have_content 'Successfully authenticated from Facebook account'
+    end
+
+    scenario 'before conform email' do
+      visit new_user_session_path
+      click_on 'Sign in with Facebook'
+
+      expect(page).to have_content 'You have to confirm your email address before continuing.'
+    end
   end
 
   scenario 'authentication error' do

--- a/spec/acceptance/authorization/sign_in_with_facebook_spec.rb
+++ b/spec/acceptance/authorization/sign_in_with_facebook_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../acceptance_helper'
+
+feature 'Sign in with facebook'do
+  before { visit new_user_session_path }
+
+  scenario 'user can sign in with his facebook account' do
+    expect(page).to have_link 'Sign in with Facebook'
+    facebook_auth_hash
+    click_on 'Sign in'
+
+    expect(page).to have_content 'Successfully authenticated from Facebook account'
+  end
+
+  scenario 'authentication error' do
+    OmniAuth.config.mock_auth[:facebook] = :invalid_credentials
+    expect(page).to have_link 'Sign in with Facebook'
+    click_on 'Sign in'
+
+    expect(page).to have_content 'Could not authenticate you from Facebook'
+  end
+end

--- a/spec/acceptance/authorization/sign_in_with_twitter_spec.rb
+++ b/spec/acceptance/authorization/sign_in_with_twitter_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../acceptance_helper'
+
+feature 'Sign in with Twitter'do
+  before { visit new_user_session_path }
+
+  scenario 'user can sign in with his Twitter account' do
+    mock_auth_hash(:twitter)
+    click_on 'Sign in with Twitter'
+
+    fill_in 'auth_info_email', with: 'user@twitter.ru'
+    click_on 'Submit'
+
+    expect(page).to have_content 'Successfully authenticated from Twitter account'
+  end
+
+  scenario 'authentication error' do
+    OmniAuth.config.mock_auth[:twitter] = :invalid_credentials
+    click_on 'Sign in with Twitter'
+
+    expect(page).to have_content 'Could not authenticate you from Twitter'
+  end
+end

--- a/spec/acceptance/authorization/sign_in_with_twitter_spec.rb
+++ b/spec/acceptance/authorization/sign_in_with_twitter_spec.rb
@@ -3,14 +3,29 @@ require_relative '../acceptance_helper'
 feature 'Sign in with Twitter'do
   before { visit new_user_session_path }
 
-  scenario 'user can sign in with his Twitter account' do
-    mock_auth_hash(:twitter)
-    click_on 'Sign in with Twitter'
+  describe 'User can sign in with his Twitter account' do
+    before do
+      mock_auth_hash(:twitter)
+      click_on 'Sign in with Twitter'
 
-    fill_in 'auth_info_email', with: 'user@twitter.ru'
-    click_on 'Submit'
+      fill_in 'auth_info_email', with: 'user@twitter.ru'
+      click_on 'Submit'
+    end
+    
+    scenario 'after conform email' do
+      open_email('user@twitter.ru')
+      current_email.click_link 'Confirm my account'
+      expect(page).to have_content 'Your email address has been successfully confirmed.'
+      click_on 'Sign in with Twitter'
+      expect(page).to have_content 'Successfully authenticated from Twitter account'
+    end
 
-    expect(page).to have_content 'Successfully authenticated from Twitter account'
+    scenario 'before conform email' do
+      visit new_user_session_path
+      click_on 'Sign in with Twitter'
+
+      expect(page).to have_content 'You have to confirm your email address before continuing.'
+    end
   end
 
   scenario 'authentication error' do

--- a/spec/acceptance/authorization/sign_in_with_vkontakte_spec.rb
+++ b/spec/acceptance/authorization/sign_in_with_vkontakte_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../acceptance_helper'
+
+feature 'Sign in with Vkontakte'do
+  before { visit new_user_session_path }
+
+  scenario 'user can sign in with his Vkontakte account' do
+    mock_auth_hash(:vkontakte)
+    click_on 'Sign in with Vkontakte'
+
+    expect(page).to have_content 'Successfully authenticated from Vkontakte account'
+  end
+
+  scenario 'authentication error' do
+    OmniAuth.config.mock_auth[:vkontakte] = :invalid_credentials
+    click_on 'Sign in with Vkontakte'
+
+    expect(page).to have_content 'Could not authenticate you from Vkontakte'
+  end
+end

--- a/spec/acceptance/authorization/sign_in_with_vkontakte_spec.rb
+++ b/spec/acceptance/authorization/sign_in_with_vkontakte_spec.rb
@@ -3,11 +3,27 @@ require_relative '../acceptance_helper'
 feature 'Sign in with Vkontakte'do
   before { visit new_user_session_path }
 
-  scenario 'user can sign in with his Vkontakte account' do
-    mock_auth_hash(:vkontakte)
-    click_on 'Sign in with Vkontakte'
+  describe 'User can sign in with his Vkontakte account' do
+    before do
+      mock_auth_hash(:vkontakte)
+      click_on 'Sign in with Vkontakte'
+    end
 
-    expect(page).to have_content 'Successfully authenticated from Vkontakte account'
+    scenario 'after conform email' do
+      open_email(OmniAuth.config.mock_auth[:vkontakte]['info']['email'])
+      current_email.click_link 'Confirm my account'
+      expect(page).to have_content 'Your email address has been successfully confirmed.'
+      click_on 'Sign in with Vkontakte'
+
+      expect(page).to have_content 'Successfully authenticated from Vkontakte account'
+    end
+
+    scenario 'before conform email' do
+      visit new_user_session_path
+      click_on 'Sign in with Vkontakte'
+
+      expect(page).to have_content 'You have to confirm your email address before continuing.'
+    end
   end
 
   scenario 'authentication error' do

--- a/spec/acceptance/user/sign_up_spec.rb
+++ b/spec/acceptance/user/sign_up_spec.rb
@@ -8,18 +8,20 @@ feature 'User sign up', %q{
 
   given(:user) { build(:user) }
 
-  scenario 'User try to sign up' do
+  before do
     sign_up(user)
+    open_email(user.email)
+    current_email.click_link 'Confirm my account'
+  end
 
-    expect(page).to have_content 'Welcome! You have signed up successfully.'
+  scenario 'User try to sign up' do
+    sign_in(user)
+    expect(page).to have_content 'Signed in successfully.'
     expect(current_path).to eq root_path
   end
 
   scenario 'Registered user try to sign up retry' do
     sign_up(user)
-    click_on 'Logout'
-    sign_up(user)
-
     expect(page).to have_content 'Email has already been taken'
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe OmniauthCallbacksController, type: :controller do
+  let(:auth) { OmniAuth::AuthHash.new(provider: 'twitter', uid: '123456', info: { email: 'new@user.com' }) }
+
+  describe 'POST #twitter' do
+    it 'saves new user' do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      expect { post :twitter, auth: auth }.to change(User, :count).by(1)
+    end
+  end
+end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,12 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe OmniauthCallbacksController, type: :controller do
-  let(:auth) { OmniAuth::AuthHash.new(provider: 'twitter', uid: '123456', info: { email: 'new@user.com' }) }
+  let(:auth_twitter) { OmniAuth::AuthHash.new(provider: 'twitter', uid: '123456', info: { email: 'new@twitter.com' }) }
+
+  before { @request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'POST #twitter' do
     it 'saves new user' do
-      @request.env["devise.mapping"] = Devise.mappings[:user]
-      expect { post :twitter, auth: auth }.to change(User, :count).by(1)
+      session['devise.auth'] = { provider: 'twitter', uid: '123456' }
+      expect { post :twitter, auth: { info: { email: 'new@twitter.com' } } }.to change(User, :count).by(1)
+    end
+  end
+
+  describe 'GET #facebook' do
+    before do
+      mock_auth_hash(:facebook)
+      @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:facebook]
+    end
+
+    it 'User already created' do
+      get :facebook
+      expect { get :facebook }.to_not change(User, :count)
+    end
+
+    it 'Create new user' do
+      expect { get :facebook }.to change(User, :count).by(1)
+    end
+  end
+
+  describe 'GET #twitter' do
+    context 'User with email' do
+      before do
+        mock_auth_hash(:twitter)
+        @request.env['omniauth.auth'] = auth_twitter
+      end
+
+      it 'User already created' do
+        get :twitter
+        expect { get :twitter }.to_not change(User, :count)
+      end
+
+      it 'Create new user' do
+        expect { get :twitter }.to change(User, :count).by(1)
+      end
+    end
+
+    context 'User without email' do
+      before do
+        mock_auth_hash(:twitter)
+        @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:twitter]
+      end
+
+      it 'User don\'t created' do
+        expect { get :twitter }.to_not change(User, :count)
+      end
+
+      it 'render email form' do
+        get :twitter
+        expect(response).to render_template 'users/require_user_email'
+      end
     end
   end
 end

--- a/spec/factories/authorizations.rb
+++ b/spec/factories/authorizations.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :authorization do
+    user nil
+provider "MyString"
+uid "MyString"
+  end
+
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,5 +7,6 @@ FactoryGirl.define do
     email
     password '12345678'
     password_confirmation '12345678'
+    confirmed_at Time.now
   end
 end

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Authorization, type: :model do
+  it { should belong_to :user }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,12 +10,19 @@ RSpec.describe User do
 
   describe '.find_for_oauth' do
     let!(:user) { create(:user) }
-    let(:auth) { OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456') }
+    let(:auth) { OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456', info: nil) }
 
     context 'user already has authorization' do
       it 'returns the user' do
         user.authorizations.create(provider: 'facebook', uid: '123456')
         expect(User.find_for_oauth(auth)).to eq user
+      end
+    end
+
+    context 'create new user instance' do
+      it 'when user doesn\'t have email address' do
+        user = User.find_for_oauth(auth)
+        expect(user).to be_a_new User
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,4 +6,69 @@ RSpec.describe User do
   it { should have_many(:votes) }
   it { should have_many(:questions) }
   it { should have_many(:answers) }
+  it { should have_many(:authorizations) }
+
+  describe '.find_for_oauth' do
+    let!(:user) { create(:user) }
+    let(:auth) { OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456') }
+
+    context 'user already has authorization' do
+      it 'returns the user' do
+        user.authorizations.create(provider: 'facebook', uid: '123456')
+        expect(User.find_for_oauth(auth)).to eq user
+      end
+    end
+
+    context 'user has not authorization' do
+      context 'user already exists' do
+        let(:auth) { OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456', info: { email: user.email }) }
+
+        it 'does not create new user' do
+          expect { User.find_for_oauth(auth) }.to_not change(User, :count)
+        end
+
+        it 'create authorization for user' do
+          expect { User.find_for_oauth(auth) }.to change(user.authorizations, :count).by(1)
+        end
+
+        it 'creates authorization with provider and uid' do
+          authorization = User.find_for_oauth(auth).authorizations.first
+          expect(authorization.provider).to eq auth.provider
+          expect(authorization.uid).to eq auth.uid
+        end
+
+        it 'returns the user' do
+          expect(User.find_for_oauth(auth)).to eq user
+        end
+      end
+
+      context 'user does not exist' do
+          let(:auth) { OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456', info: { email: 'new@user.com' }) }
+
+          it 'creates new user' do
+            expect { User.find_for_oauth(auth) }.to change(User, :count).by(1)
+          end
+
+          it 'returns new user' do
+              expect(User.find_for_oauth(auth)).to be_a(User)
+          end
+
+          it 'fills user email' do
+            user = User.find_for_oauth(auth)
+            expect(user.email).to eq auth.info.email
+          end
+
+          it 'creates authorization for user' do
+            user = User.find_for_oauth(auth)
+            expect(user.authorizations).to_not be_empty
+          end
+
+          it 'creates authorization with provider and uid' do
+            authorization = User.find_for_oauth(auth).authorizations.first
+            expect(authorization.provider).to eq auth.provider
+            expect(authorization.uid).to eq auth.uid
+          end
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Devise::TestHelpers, type: :controller
   config.extend ControllerMacros, type: :controller
+  config.include OmniauthMacros
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -54,6 +55,8 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 end
+
+OmniAuth.config.test_mode = true
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -1,0 +1,5 @@
+module OmniauthMacros
+  def facebook_auth_hash
+    OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456', info: { email: 'user@email.ru' })
+  end
+end

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -1,5 +1,5 @@
 module OmniauthMacros
-  def facebook_auth_hash
-    OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456', info: { email: 'user@email.ru' })
+  def mock_auth_hash(auth_provider)
+    OmniAuth.config.mock_auth[auth_provider] = OmniAuth::AuthHash.new(provider: auth_provider.to_s, uid: '123456', info: { email: "user@#{auth_provider.to_s}.ru" })
   end
 end

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -1,5 +1,6 @@
 module OmniauthMacros
   def mock_auth_hash(auth_provider)
-    OmniAuth.config.mock_auth[auth_provider] = OmniAuth::AuthHash.new(provider: auth_provider.to_s, uid: '123456', info: { email: "user@#{auth_provider.to_s}.ru" })
+    email = auth_provider == :twitter ? nil : "user@#{auth_provider.to_s}.ru"
+    OmniAuth.config.mock_auth[auth_provider] = OmniAuth::AuthHash.new(provider: auth_provider.to_s, uid: '123456', info: { email: email })
   end
 end


### PR DESCRIPTION
Реализовать аутентификацию через Facebook и Twitter. При аутентификации через Twitter запрашивать email пользователя дополнительно.
При указании email'а после входа через Twitter, отсылать письмо на указанный email со ссылкой на подтверждение этого email. Не аутентифицировать пользователя до тех пор, пока он не подтвердит указанный email. После подтверждения, пользователь может входить через twitter без дополнительных запросов на ввод или подтверждение email.